### PR TITLE
Update from smart quotes to & codes (such as "&rsquo;")

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# smart-quotes-plus package
+# smart-quotes-html fork 
+
+This fork replaces straight double and single quotes with HTML `&` codes instead of with unicode characters. Otherwise, functionally the same as smart-quotes-plus by blakegarretson. Thanks Blake!
+
+# smart-quotes-plus readme
 
 This package replaces straight quotes with smart unicode curly quotes, as well as a few other handy replacements.  Straight quotes like " and ' are converted to curly quotes (including apostrophes in contractions) to turn `"this"` and `'this'` into `“this”` and `‘this’`.  The default key-binding is `CTRL-ALT-'`.  You clearly would only want to run this on prose.  If it screws something up, just hit `CTRL-Z` to undo the replacement.
 

--- a/lib/smart-quotes-plus.coffee
+++ b/lib/smart-quotes-plus.coffee
@@ -19,28 +19,28 @@ smartreplace = (editor) ->
 
 doreplacement = (text) ->
 
-    open_double_single = "“‘"
-    open_single_double = "‘“"
-    open_double = "“"
-    open_single = "‘"
-    close_single_double = "’”"
-    close_double_single = "”’"
-    close_double = "”"
-    close_single = "’"
+    left_double_single = "&ldquo;&lsquo;"
+    left_single_double = "&lsquo;&ldquo;"
+    left_double = "&ldquo;"
+    left_single = "&lsquo;"
+    right_single_double = "&rsquo;&rdquo;"
+    right_double_single = "&rdquo;&rsquo;"
+    right_double = "&rdquo;"
+    right_single = "&rsquo;"
 
     # quotes
-    text = text.replace /"'(?=\w)/g, ($0) -> open_double_single
-    text = text.replace /([\w\.\!\?\%,])'"/g, ($0, $1) -> $1+close_single_double
-    text = text.replace /'"(?=\w)/g, ($0) -> open_single_double
-    text = text.replace /([\w\.\!\?\%,])"'/g, ($0, $1) -> $1+close_double_single
-    text = text.replace /"(?=\w)/g, ($0) -> open_double
-    text = text.replace /([\w.!?%,])"/g, ($0, $1) -> $1+close_double
-    text = text.replace /([\w.!?%,])'/g, ($0, $1) -> $1+close_single
+    text = text.replace /"'(?=\w)/g, ($0) -> left_double_single
+    text = text.replace /([\w\.\!\?\%,])'"/g, ($0, $1) -> $1+right_single_double
+    text = text.replace /'"(?=\w)/g, ($0) -> left_single_double
+    text = text.replace /([\w\.\!\?\%,])"'/g, ($0, $1) -> $1+right_double_single
+    text = text.replace /"(?=\w)/g, ($0) -> left_double
+    text = text.replace /([\w.!?%,])"/g, ($0, $1) -> $1+right_double
+    text = text.replace /([\w.!?%,])'/g, ($0, $1) -> $1+right_single
 
     # single tick use cases
-    text = text.replace /([\s])'(?=(tis\b|twas\b))/g, ($0, $1) -> $1+close_single
-    text = text.replace /(\s)'(?=[0-9]+s*\b)/g, ($0, $1) -> $1+close_single
-    text = text.replace /([^\w]|^)'(?=\w)/g, ($0, $1, $2) -> $1+open_single
+    text = text.replace /([\s])'(?=(tis\b|twas\b))/g, ($0, $1) -> $1+right_single
+    text = text.replace /(\s)'(?=[0-9]+s*\b)/g, ($0, $1) -> $1+right_single
+    text = text.replace /([^\w]|^)'(?=\w)/g, ($0, $1, $2) -> $1+left_single
 
     # misc chars
     text = text.replace /\.\.\./g, "…"


### PR DESCRIPTION
This fix eliminates missing character icons in browsers when this package is used for HTML files. Updated names to match `&` codes better (`left_double` corresponds better with ` &ldquo;`).